### PR TITLE
[DO NOT MERGE] Clip gradient norm refactor

### DIFF
--- a/sources/ttml/autograd/clip_gradient_norm.cpp
+++ b/sources/ttml/autograd/clip_gradient_norm.cpp
@@ -21,9 +21,9 @@ void clip_tensor_norm_(tt::tt_metal::Tensor& tensor, float max_norm) {
     ttnn::moreh_sum(squared, std::nullopt, true, out, squared.memory_config(), core::ComputeKernelConfig::precise());
     auto grad_norm_tensor = ttnn::sqrt(out);
 
-    auto grad_norm_tensor_repeated = ttnn::repeat(grad_norm_tensor, tensor.get_shape().logical_shape());
-    auto inv_grad_norm_tensor_repeated = ttnn::reciprocal(grad_norm_tensor);
-    auto scale = ttnn::multiply(inv_grad_norm_tensor_repeated, max_norm);
+    auto grad_norm_tensor_repeated = ttnn::repeat(grad_norm_tensor, tensor.get_logical_shape());
+    auto inv_grad_norm_tensor = ttnn::reciprocal(grad_norm_tensor);
+    auto scale = ttnn::multiply(inv_grad_norm_tensor, max_norm);
     auto scaled_tensor = ttnn::multiply(tensor, scale);
     core::print_tensor_stats(tensor, "tensor");
     core::print_tensor_stats(grad_norm_tensor, "grad_norm_tensor");


### PR DESCRIPTION
### Description
Refactor clip gradient norm method to avoid moving data to host. 
Current blocked by `ttnn::repeat`  [issue](https://github.com/tenstorrent/tt-metal/issues/14443)


### Changes Made
- [ ] **New Feature:** Describe the new feature and its purpose.
- [ ] **Improvement:** Summarize the enhancements implemented.
- [ ] **Bug Fix:** Detail the issue that was addressed.
- [x] **Refactor:** Outline any significant code refactoring efforts.

### Testing
- [ ] Unit tests added or updated
- [ ] Manual testing conducted

### Review Checklist
- [x] No breaking changes introduced
- [ ] All tests pass successfully
- [x] Code complies with project style guidelines

