### PR TITLE
Change CoreGrid from 8x8 to 7x8 cores

### DIFF
--- a/sources/ttml/ops/linear_op.cpp
+++ b/sources/ttml/ops/linear_op.cpp
@@ -29,7 +29,7 @@ tt::tt_metal::Tensor matmul(
         /* activation */ std::nullopt,
         /* compute_kernel_config */
         config,
-        /* core_grid */ ttnn::CoreGrid{8, 8},
+        /* core_grid */ ttnn::CoreGrid{7, 8},
         /* output_tile */ std::nullopt);
 }
 
@@ -120,7 +120,7 @@ autograd::TensorPtr linear_op(
         /* program_config */ std::nullopt,
         /* activation */ std::nullopt,
         /* compute_kernel_config */ core::ComputeKernelConfig::matmul(),
-        /* core_grid */ ttnn::CoreGrid{8, 8}));
+        /* core_grid */ ttnn::CoreGrid{7, 8}));
 
     autograd::GradFunction grad = [weight, bias, tensor, out]() {
         auto tensor_shape = tensor->get_value().get_shape();

--- a/sources/ttml/ops/scaled_dot_product_attention.cpp
+++ b/sources/ttml/ops/scaled_dot_product_attention.cpp
@@ -24,7 +24,7 @@ tt::tt_metal::Tensor matmul(
         /* program_config */ std::nullopt,
         /* activation */ std::nullopt,
         /* compute_kernel_config */ core::ComputeKernelConfig::matmul(),
-        /* core_grid */ ttnn::CoreGrid{8, 8},
+        /* core_grid */ ttnn::CoreGrid{7, 8},
         /* output_tile */ std::nullopt);
 }
 


### PR DESCRIPTION
### Description
Current use of CoreGrid results in frequent device crashes. To avoid that we find out that we should use less cores for matmul, specifically 7x8 (we tested 8x7, but it also resulted in device crashes).

### Changes Made
- [ ] **New Feature:** Describe the new feature and its purpose.
- [ ] **Improvement:** Summarize the enhancements implemented.
- [x] **Bug Fix:** Detail the issue that was addressed.
- [ ] **Refactor:** Outline any significant code refactoring efforts.

### Testing
- [x] Unit tests added or updated
- [x] Manual testing conducted

### Review Checklist
- [x] No breaking changes introduced
- [x] All tests pass successfully
- [x] Code complies with project style guidelines
